### PR TITLE
インバウンドポートの修正

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -7,7 +7,7 @@ pid "#{app_path}/tmp/pids/unicorn.pid"
 stderr_path "#{app_path}/log/unicorn.stderr.log"
 stdout_path "#{app_path}/log/unicorn.stdout.log"
 
-listen 80
+listen 3000
 timeout 60
 
 preload_app true


### PR DESCRIPTION
# What
AWSのインバウンドポートを修正

# Why
Listen 80でサーバーが立ち上がらなくなったため